### PR TITLE
Update legacy.md for Pkg: FLAGS_MISMATCH

### DIFF
--- a/legacy.md
+++ b/legacy.md
@@ -24,6 +24,8 @@ helm init --service-account tiller
     # OR
     create-secrets\index.win.exe
 ```
+You need to unset your `NODE_OPTIONS` env variable if you run into `Pkg: FLAGS_MISMATCH` while running the secrets script.
+
 Output should look something like so:
 ```
 magda-create-secrets tool 


### PR DESCRIPTION
Just ran into this trying to run the secrets script

See:
https://github.com/zeit/pkg/issues/484